### PR TITLE
remove Player structure; use Coords across the project

### DIFF
--- a/contracts/cheddar_5x5_tic_tac_toe/README.md
+++ b/contracts/cheddar_5x5_tic_tac_toe/README.md
@@ -8,6 +8,8 @@ X ▢ ▢ ▢ ▢
 
 ## Cheddar 5X5 TIC-TAC-TOE Game
 
+### Who starts th game?
+The starting player is selected at the beginning of the game using NEAR random mechanism. The player that stards will always have `O` piece and the other `X`.
 
 #### setup environment
 ```sh

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -71,7 +71,7 @@ impl Board {
         }
         Ok(())
     }
-    pub fn check_winner(&self, position: Coords) -> bool {
+    pub fn check_winner(&self, position: &Coords) -> bool {
         let expected = Some(self.current_piece.other());
         let mut c  = position.clone();
         let mut counter = 1;
@@ -198,7 +198,7 @@ impl Board {
     /// that the last move was made in.
     /// To find a potential winner, we only need to check the row, column and (maybe) diagonal
     /// that the last move was made in.
-    pub fn update_winner(&mut self, coords: Coords) {
+    pub fn update_winner(&mut self, coords: &Coords) {
         if self.tiles.len() >= (BOARD_SIZE * BOARD_SIZE) as u64 {
             self.winner = Some(Winner::Tie);
             return;
@@ -261,7 +261,7 @@ mod test {
         let board = Board::new(game_id);
 
         // make move
-        let _ = board.check_move(Coords{x:0, y:0});
+        let _ = board.check_move(&Coords{x:0, y:0});
     }
     #[test]
     fn index_out_of_bound() {
@@ -270,7 +270,7 @@ mod test {
         let board = Board::new(game_id);
 
         // make move
-        let result = board.check_move(Coords {x: BOARD_SIZE as u8, y: BOARD_SIZE as u8});
+        let result = board.check_move(&Coords {x: BOARD_SIZE as u8, y: BOARD_SIZE as u8});
         assert_eq!(
             result,
             Err(MoveError::InvalidPosition {
@@ -289,7 +289,7 @@ mod test {
 
         // make move
         board.tiles.insert(&Coords { x: 0, y: 0 }, &piece_1);
-        let result = board.check_move(Coords{x:0, y:0});
+        let result = board.check_move(&Coords{x:0, y:0});
         assert_eq!(
             result,
             Err(MoveError::TileFilled {
@@ -322,7 +322,7 @@ mod test {
         board.tiles.insert(&Coords { x: 1, y: 1 }, &piece_2);
         board.tiles.insert(&Coords { x: 2, y: 1 }, &piece_2);
         board.tiles.insert(&Coords { x: 3, y: 1 }, &piece_2);
-        let result = board.check_winner(Coords { x: 4, y: 1 });
+        let result = board.check_winner(&Coords { x: 4, y: 1 });
         assert_eq!(result, true);
     }
     #[test]
@@ -342,7 +342,7 @@ mod test {
         board.tiles.insert(&Coords { x: 0, y: 1 }, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 2 }, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 3 }, &piece_2);
-        let result = board.check_winner(Coords { x: 0, y: 4 });
+        let result = board.check_winner(&Coords { x: 0, y: 4 });
         assert_eq!(result, true);
     }
     #[test]
@@ -363,7 +363,7 @@ mod test {
         board.tiles.insert(&Coords { x: 0, y: 2 }, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 3 }, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 4 }, &piece_2);
-        let result = board.check_winner(Coords { x: 0, y: 0 });
+        let result = board.check_winner(&Coords { x: 0, y: 0 });
         assert_eq!(result, true);
     }
     #[test]
@@ -384,7 +384,7 @@ mod test {
         board.tiles.insert(&Coords { x: 0, y: 1 }, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 3 }, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 4 }, &piece_2);
-        let result = board.check_winner(Coords { x: 0, y: 2 });
+        let result = board.check_winner(&Coords { x: 0, y: 2 });
         assert_eq!(result, true);
     }
     #[test]
@@ -405,7 +405,7 @@ mod test {
         board.tiles.insert(&Coords { x: 1, y: 1 }, &piece_2);
         board.tiles.insert(&Coords { x: 2, y: 2 }, &piece_2);
         board.tiles.insert(&Coords { x: 3, y: 3 }, &piece_2);
-        let result = board.check_winner(Coords { x: 4, y: 4 });
+        let result = board.check_winner(&Coords { x: 4, y: 4 });
         assert_eq!(result, true);
     }
     #[test]
@@ -426,7 +426,7 @@ mod test {
         board.tiles.insert(&Coords { x: 1, y: 1}, &piece_2);
         board.tiles.insert(&Coords { x: 2, y: 2}, &piece_2);
         board.tiles.insert(&Coords { x: 3, y: 3}, &piece_2);
-        let result = board.check_winner(Coords{ x: 0, y: 0 });
+        let result = board.check_winner(&Coords{ x: 0, y: 0 });
         assert_eq!(result, true); 
     }
     #[test]
@@ -447,7 +447,7 @@ mod test {
         board.tiles.insert(&Coords { x: 1, y: 1}, &piece_2);
         board.tiles.insert(&Coords { x: 4, y: 4}, &piece_2);
         board.tiles.insert(&Coords { x: 3, y: 3}, &piece_2);
-        let result = board.check_winner(Coords{ x: 2, y: 2 });
+        let result = board.check_winner(&Coords{ x: 2, y: 2 });
         assert_eq!(result, true); 
     }
     #[test]
@@ -468,7 +468,7 @@ mod test {
         board.tiles.insert(&Coords { x: 3, y: 1 }, &piece_2);
         board.tiles.insert(&Coords { x: 2, y: 2 }, &piece_2);
         board.tiles.insert(&Coords { x: 1, y: 3 }, &piece_2);
-        let result = board.check_winner(Coords { x: 0, y: 4 });
+        let result = board.check_winner(&Coords { x: 0, y: 4 });
         assert_eq!(result, true);
     }
     #[test]
@@ -489,7 +489,7 @@ mod test {
         board.tiles.insert(&Coords { x: 1, y: 3}, &piece_2);
         board.tiles.insert(&Coords { x: 2, y: 2}, &piece_2);
         board.tiles.insert(&Coords { x: 3, y: 1}, &piece_2);
-        let result = board.check_winner(Coords{ x: 4, y: 0 });
+        let result = board.check_winner(&Coords{ x: 4, y: 0 });
         assert_eq!(result, true); 
     }
     #[test]
@@ -510,7 +510,7 @@ mod test {
         board.tiles.insert(&Coords { x: 3, y: 1}, &piece_2);
         board.tiles.insert(&Coords { x: 2, y: 2}, &piece_2);
         board.tiles.insert(&Coords { x: 0, y: 4}, &piece_2);
-        let result = board.check_winner(Coords{ x: 1, y: 3 });
+        let result = board.check_winner(&Coords{ x: 1, y: 3 });
         assert_eq!(result, true); 
     }
     #[test]

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -16,16 +16,16 @@ pub enum MoveError {
     /// The game was already over when a move was attempted
     GameOver,
     /// The position provided was invalid
-    InvalidPosition { row: usize, col: usize },
+    InvalidPosition { row: u8, col: u8 },
     /// The tile already contained another piece
     TileFilled {
         other_piece: Piece,
-        row: usize,
-        col: usize,
+        row: u8,
+        col: u8,
     },
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Clone)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
 #[serde(crate = "near_sdk::serde")]
 pub struct Coords {
@@ -47,46 +47,34 @@ impl Board {
     /// there is two players with different AccountId's and
     /// with different random given pieces
     /// accounts check in `Game.create_game`
-    pub fn new(game_id: GameId, player_1: &Player, player_2: &Player) -> Self {
-        assert_ne!(
-            player_1.piece, player_2.piece,
-            "players have same pieces: {:?}",
-            player_1.piece
-        );
+    pub fn new(game_id: GameId) -> Self {
         Self {
             tiles: UnorderedMap::new(StorageKey::GameBoard { game_id }),
-            current_piece: player_1.piece,
+            current_piece: Piece::O,
             winner: None,
         }
     }
-    pub fn check_move(&self, row: usize, col: usize) -> Result<(), MoveError> {
+    pub fn check_move(&self, coords: Coords) -> Result<(), MoveError> {
         if self.winner.is_some() {
             return Err(MoveError::GameOver);
         }
-        if row >= BOARD_SIZE || col >= BOARD_SIZE {
-            return Err(MoveError::InvalidPosition { row, col });
+        if coords.y >= BOARD_SIZE as u8 || coords.x >= BOARD_SIZE as u8 {
+            return Err(MoveError::InvalidPosition { row: coords.y, col: coords.x });
         }
         // Move in already filled tile
-        else if let Some(other_piece) = self.tiles.get(&Coords {
-            x: col as u8,
-            y: row as u8,
-        }) {
+        else if let Some(other_piece) = self.tiles.get(&coords) {
             return Err(MoveError::TileFilled {
                 other_piece,
-                row,
-                col,
+                row: coords.y,
+                col: coords.x,
             });
         }
         Ok(())
     }
     pub fn check_winner(&self, position: Coords) -> bool {
         let expected = Some(self.current_piece.other());
-        let mut c: Coords = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        let mut c  = position.clone();
         let mut counter = 1;
-
         // 1. check rows
         // go max 4 pos to the left and see how far we can go
         for _ in 1..=min(4, position.x) {
@@ -100,10 +88,7 @@ impl Board {
         if counter >= 5 {
             return true;
         }
-        c = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        c = position.clone();
         for _ in 1..=max(4, BOARD_SIZE - 1 - position.x as usize) {
             c.x = c.x + 1;
             if self.tiles.get(&c) == expected {
@@ -115,11 +100,8 @@ impl Board {
                 return true;
             }
         }
-        // 2. check collumns
-        c = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        // 2. check columns
+        c = position.clone();
         counter = 1;
         for _ in 1..=min(4, position.y) {
             c.y = c.y - 1;
@@ -132,10 +114,7 @@ impl Board {
         if counter >= 5 {
             return true;
         }
-        c = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        c = position.clone();
         for _ in 1..=max(4, BOARD_SIZE - 1 - position.y as usize) {
             c.y = c.y + 1;
             if self.tiles.get(&c) == expected {
@@ -154,10 +133,7 @@ impl Board {
         //     o o o x X x
         //     o o o x x X
         //     x x o x o x
-        c = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        c = position.clone();
         counter = 1;
         for _ in 1..=min(4, min(position.x, position.y)) {
             c.x = c.x - 1;
@@ -171,10 +147,7 @@ impl Board {
         if counter >= 5 {
             return true;
         }
-        c = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        c = position.clone();
         for _ in 1..=max(
             4,
             BOARD_SIZE - 1 - max(position.x as usize, position.y as usize),
@@ -192,10 +165,7 @@ impl Board {
         }
 
         //4. check diagonal (NE - SW)
-        c = Coords {
-            x: position.x.clone(),
-            y: position.y.clone(),
-        };
+        c = position.clone();
         let mut counter = 1;
         for _ in 1..=position.y {
             c.x = c.x + 1;
@@ -209,7 +179,7 @@ impl Board {
         if counter >= 5 {
             return true;
         }
-        c = Coords { x: position.x.clone(), y: position.y.clone() };
+        c = position.clone();
         for _ in 1..=position.x {
             c.x = c.x - 1;
             c.y = c.y + 1;
@@ -276,65 +246,50 @@ impl Board {
 }
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
-    use near_sdk::AccountId;
-
     use super::Board;
     use super::MoveError;
     use crate::{
         board::Coords,
-        player::{Piece, Player},
+        player::Piece,
         utils::BOARD_SIZE,
     };
 
     #[test]
     fn valid_move() {
-        // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
         let game_id: u64 = 1;
         // initialize the board
-        let board = Board::new(game_id, &player_1, &player_2);
+        let board = Board::new(game_id);
 
         // make move
-        let _ = board.check_move(0, 0);
+        let _ = board.check_move(Coords{x:0, y:0});
     }
     #[test]
     fn index_out_of_bound() {
-        // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
         let game_id: u64 = 1;
         // initialize the board
-        let board = Board::new(game_id, &player_1, &player_2);
+        let board = Board::new(game_id);
 
         // make move
-        let result = board.check_move(BOARD_SIZE, BOARD_SIZE);
+        let result = board.check_move(Coords {x: BOARD_SIZE as u8, y: BOARD_SIZE as u8});
         assert_eq!(
             result,
             Err(MoveError::InvalidPosition {
-                row: BOARD_SIZE,
-                col: BOARD_SIZE
+                row: BOARD_SIZE as u8,
+                col: BOARD_SIZE as u8
             })
         );
     }
     #[test]
     fn alreddy_taken_field() {
-        // create two players
+        // create random Piece
         let piece_1 = Piece::random();
-        let piece_2 = piece_1.other();
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // make move
         board.tiles.insert(&Coords { x: 0, y: 0 }, &piece_1);
-        let result = board.check_move(0, 0);
+        let result = board.check_move(Coords{x:0, y:0});
         assert_eq!(
             result,
             Err(MoveError::TileFilled {
@@ -347,13 +302,11 @@ mod test {
     #[test]
     fn check_row_winner() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_1 = Piece::O;
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // O O O O _
@@ -375,13 +328,10 @@ mod test {
     #[test]
     fn check_column_winner_1() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
         // prepare the board
         // O _ _ _ _
         // O _ _ _ _
@@ -398,13 +348,10 @@ mod test {
     #[test]
     fn check_column_winner_2() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // _ _ _ _ _
@@ -422,13 +369,10 @@ mod test {
     #[test]
     fn check_column_winner_3() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // O _ _ _ _
@@ -446,13 +390,10 @@ mod test {
     #[test]
     fn check_se_diagonal_winner_1() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // O _ _ _ _
@@ -470,13 +411,10 @@ mod test {
     #[test]
     fn check_se_diagonal_winner_2() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // _  _ _ _ _
@@ -494,13 +432,10 @@ mod test {
     #[test]
     fn check_se_diagonal_winner_3() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // O _ _ _ _
@@ -518,13 +453,10 @@ mod test {
     #[test]
     fn check_sw_diagonal_winner_1() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // _ _ _ _ O
@@ -542,13 +474,10 @@ mod test {
     #[test]
     fn check_sw_diagonal_winner_2() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // _ _ _ _ _
@@ -566,13 +495,10 @@ mod test {
     #[test]
     fn check_sw_diagonal_winner_3() {
         // create two players
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // prepare the board
         // _ _ _ _ O
@@ -589,13 +515,10 @@ mod test {
     }
     #[test]
     fn test_get_vector() {
-        let piece_1 = Piece::X;
-        let piece_2 = Piece::O;
-        let player_1 = Player::new(piece_1, AccountId::new_unchecked("test1".into()));
-        let player_2 = Player::new(piece_2, AccountId::new_unchecked("test2".into()));
+        let piece_2 = Piece::X;
         let game_id: u64 = 1;
         // initialize the board
-        let mut board = Board::new(game_id, &player_1, &player_2);
+        let mut board = Board::new(game_id);
 
         // insert few testing values
         // _ _ _ _ O

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -54,7 +54,7 @@ impl Board {
             winner: None,
         }
     }
-    pub fn check_move(&self, coords: Coords) -> Result<(), MoveError> {
+    pub fn check_move(&self, coords: &Coords) -> Result<(), MoveError> {
         if self.winner.is_some() {
             return Err(MoveError::GameOver);
         }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
@@ -254,7 +254,7 @@ impl Contract {
     }
 
     // TODO: we don't need to return the board: UI should update by checking if transaction failed or not.
-    pub fn make_move(&mut self, game_id: &GameId, row: usize, col: usize) -> [[Option<Piece>; BOARD_SIZE]; BOARD_SIZE] {
+    pub fn make_move(&mut self, game_id: &GameId, coords: Coords) -> [[Option<Piece>; BOARD_SIZE]; BOARD_SIZE] {
         let cur_timestamp = env::block_timestamp();
         //checkpoint
         self.internal_ping_expired_games(cur_timestamp);
@@ -263,16 +263,16 @@ impl Contract {
 
         assert_eq!(env::predecessor_account_id(), game.current_player_account_id(), "not your turn");
         assert_eq!(game.game_state, GameState::Active, "Current game isn't active");
-
-        match game.board.check_move(row, col) {
+        let c = coords.clone();
+        match game.board.check_move(coords) {
             Ok(_) => {
                 // fill board tile with current player piece
-                game.board.tiles.insert(&Coords {y: row as u8, x: col as u8}, &game.current_piece);
+                game.board.tiles.insert(&c, &game.current_piece);
                 // switch piece to other one
                 game.current_piece = game.current_piece.other();
                 // switch player
                 game.current_player_index = 1 - game.current_player_index;
-                game.board.update_winner(Coords {y: row as u8, x: col as u8});
+                game.board.update_winner(c);
 
                 if let Some(winner) = game.board.winner.clone() {
                     // change game state to Finished
@@ -611,13 +611,13 @@ mod tests {
         ctr: &mut Contract,
         user: &AccountId,
         game_id: &GameId,
-        row: usize,
-        col: usize
+        row: u8,
+        col: u8
     ) -> [[Option<Piece>; BOARD_SIZE]; BOARD_SIZE] {
         testing_env!(ctx
             .predecessor_account_id(user.clone())
             .build());
-        ctr.make_move(game_id, row, col)
+        ctr.make_move(game_id, Coords{y: row, x: col})
     }
 
     fn stop_game(
@@ -952,10 +952,9 @@ mod tests {
         let player_2 = game.next_player_account_id().clone();
 
         assert_ne!(player_1, game.next_player_account_id());
-        assert_ne!(game.players.0.piece, game.players.1.piece);
-        assert_eq!(player_1, game.players.0.account_id);
-        assert_eq!(player_2, game.players.1.account_id);
-        assert_eq!(game.board.current_piece, game.players.0.piece);
+        assert_eq!(player_1, game.players.0);
+        assert_eq!(player_2, game.players.1);
+        assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
@@ -1035,10 +1034,9 @@ mod tests {
         println!("( {} , {} )", player_1, player_2);
 
         assert_ne!(player_1, game.next_player_account_id());
-        assert_ne!(game.players.0.piece, game.players.1.piece);
-        assert_eq!(player_1, game.players.0.account_id);
-        assert_eq!(player_2, game.players.1.account_id);
-        assert_eq!(game.board.current_piece, game.players.0.piece);
+        assert_eq!(player_1, game.players.0);
+        assert_eq!(player_2, game.players.1);
+        assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
@@ -1141,10 +1139,9 @@ mod tests {
         println!("( {} , {} )", player_1, player_2);
 
         assert_ne!(player_1, game.next_player_account_id());
-        assert_ne!(game.players.0.piece, game.players.1.piece);
-        assert_eq!(player_1, game.players.0.account_id);
-        assert_eq!(player_2, game.players.1.account_id);
-        assert_eq!(game.board.current_piece, game.players.0.piece);
+        assert_eq!(player_1, game.players.0);
+        assert_eq!(player_2, game.players.1);
+        assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
@@ -1199,10 +1196,9 @@ mod tests {
         println!("( {} , {} )", player_1, player_2);
 
         assert_ne!(player_1, game.next_player_account_id());
-        assert_ne!(game.players.0.piece, game.players.1.piece);
-        assert_eq!(player_1, game.players.0.account_id);
-        assert_eq!(player_2, game.players.1.account_id);
-        assert_eq!(game.board.current_piece, game.players.0.piece);
+        assert_eq!(player_1, game.players.0);
+        assert_eq!(player_2, game.players.1);
+        assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
@@ -1515,10 +1511,9 @@ mod tests {
         println!("( {} , {} )", player_1, player_2);
 
         assert_ne!(player_1, game.next_player_account_id());
-        assert_ne!(game.players.0.piece, game.players.1.piece);
-        assert_eq!(player_1, game.players.0.account_id);
-        assert_eq!(player_2, game.players.1.account_id);
-        assert_eq!(game.board.current_piece, game.players.0.piece);
+        assert_eq!(player_1, game.players.0);
+        assert_eq!(player_2, game.players.1);
+        assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
@@ -1577,10 +1572,9 @@ mod tests {
         println!("( {} , {} )", player_1, player_2);
 
         assert_ne!(player_1, game.next_player_account_id());
-        assert_ne!(game.players.0.piece, game.players.1.piece);
-        assert_eq!(player_1, game.players.0.account_id);
-        assert_eq!(player_2, game.players.1.account_id);
-        assert_eq!(game.board.current_piece, game.players.0.piece);
+        assert_eq!(player_1, game.players.0);
+        assert_eq!(player_2, game.players.1);
+        assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
@@ -1598,5 +1592,10 @@ mod tests {
         // player2 turn still have time left to make a move -> dont change anything just log that the claim is not valid yet 
         ctr.claim_timeout_win(&game_id);
         assert!(game.game_state == GameState::Active);
+    }
+    #[test] 
+    fn test_player_piece_binding() {
+        let board = Board::new(1);
+        assert_eq!(board.current_piece, Piece::O);
     }
 }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
@@ -263,16 +263,15 @@ impl Contract {
 
         assert_eq!(env::predecessor_account_id(), game.current_player_account_id(), "not your turn");
         assert_eq!(game.game_state, GameState::Active, "Current game isn't active");
-        let c = coords.clone();
-        match game.board.check_move(coords) {
+        match game.board.check_move(&coords) {
             Ok(_) => {
                 // fill board tile with current player piece
-                game.board.tiles.insert(&c, &game.current_piece);
+                game.board.tiles.insert(&coords, &game.current_piece);
                 // switch piece to other one
                 game.current_piece = game.current_piece.other();
                 // switch player
                 game.current_player_index = 1 - game.current_player_index;
-                game.board.update_winner(c);
+                game.board.update_winner(&coords);
 
                 if let Some(winner) = game.board.winner.clone() {
                     // change game state to Finished

--- a/contracts/cheddar_5x5_tic_tac_toe/src/player.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/player.rs
@@ -22,20 +22,3 @@ impl Piece {
         }
     }
 }
-
-/// Player struct with X/O and `AccountId`
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(crate = "near_sdk::serde")]
-pub struct Player {
-	pub piece : Piece,
-    pub account_id: AccountId
-}
-
-impl Player {
-    pub fn new(piece: Piece, account_id: AccountId) -> Self {
-        Self { 
-            piece, 
-            account_id
-        }
-    }
-}

--- a/contracts/cheddar_5x5_tic_tac_toe/src/views.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/views.rs
@@ -27,7 +27,7 @@ pub struct GameView {
     pub player1: AccountId,
     pub player2: AccountId,
     pub game_status: GameState,
-    pub current_player: Player,
+    pub current_player: AccountId,
     pub reward: GameDeposit,
     pub tiles: [[Option<Piece>; BOARD_SIZE]; BOARD_SIZE],
     /* * */
@@ -71,7 +71,7 @@ impl From<&Game> for RangedPlayersView {
 impl From<&Game> for GameView {
     fn from(g: &Game) -> Self {
         let (player1, player2) = g.get_player_accounts();
-        let current_player: Player = match g.current_player_index {
+        let current_player: AccountId = match g.current_player_index {
             0 => g.players.0.clone(),
             _ => g.players.1.clone(),
         };


### PR DESCRIPTION
Changes:
+ Remove `Player` structure. Now we assume that the first player is `O` and the second is `X`
+ Use `Coords` struct across the project instead of `row` and `col` as separate parameters
