### PR TITLE
Support cheddar

### DIFF
--- a/contracts/cheddar_3x3_tic_tac_toe/src/internal.rs
+++ b/contracts/cheddar_3x3_tic_tac_toe/src/internal.rs
@@ -116,14 +116,12 @@ impl Contract {
 
             self.internal_distribute_fee(&token_id, fees_amount, winner_id);
             self.internal_update_stats(
-                Some(&token_id), 
                 winner_id, 
                 UpdateStatsAction::AddWonGame, 
                 None, 
                 None
             );
             self.internal_update_stats(
-                Some(&token_id), 
                 winner_id, 
                 UpdateStatsAction::AddTotalReward, 
                 None, 
@@ -167,7 +165,6 @@ impl Contract {
             if computed_referrer_fee > 0 {
                 log!("Affiliate reward for @{} is {}", referrer_id, computed_referrer_fee);
                 self.internal_update_stats(
-                    Some(token_id), 
                     &referrer_id, 
                     UpdateStatsAction::AddAffiliateReward, 
                     None, 
@@ -201,7 +198,6 @@ impl Contract {
         assert_eq!(game.game_state, GameState::Active, "Current game isn't active");
         
         self.internal_update_stats(
-            None, 
             &looser, 
             UpdateStatsAction::AddPenaltyGame, 
             None, 
@@ -254,8 +250,8 @@ impl Contract {
 
     pub (crate) fn internal_add_referrer(&mut self, player_id: &AccountId, referrer_id: &AccountId) {
         if self.stats.get(player_id).is_none() && self.is_account_exists(referrer_id) {
-            self.internal_update_stats(None, player_id, UpdateStatsAction::AddReferral, Some(referrer_id.clone()), None);
-            self.internal_update_stats(None, referrer_id, UpdateStatsAction::AddAffiliate, Some(player_id.clone()), None);
+            self.internal_update_stats(player_id, UpdateStatsAction::AddReferral, Some(referrer_id.clone()), None);
+            self.internal_update_stats(referrer_id, UpdateStatsAction::AddAffiliate, Some(player_id.clone()), None);
             log!("Referrer {} added for {}", referrer_id, player_id);
         } else {
             log!("Referrer was not added")

--- a/contracts/cheddar_3x3_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_3x3_tic_tac_toe/src/lib.rs
@@ -255,8 +255,8 @@ impl Contract {
                 self.internal_add_referrer(&player_2_id, &referrer_id);
             }
 
-            self.internal_update_stats(Some(&token_id), &player_1_id, UpdateStatsAction::AddPlayedGame, None, None);
-            self.internal_update_stats(Some(&token_id), &player_2_id, UpdateStatsAction::AddPlayedGame, None, None);
+            self.internal_update_stats(&player_1_id, UpdateStatsAction::AddPlayedGame, None, None);
+            self.internal_update_stats(&player_2_id, UpdateStatsAction::AddPlayedGame, None, None);
             game_id
         } else {
             panic!("Your opponent is not ready");
@@ -445,7 +445,6 @@ impl Contract {
         };
 
         self.internal_update_stats(
-            Some(&game.reward().token_id), 
             &looser, 
             UpdateStatsAction::AddPenaltyGame, 
             None, 
@@ -765,15 +764,8 @@ mod tests {
         assert!(
             player_2_stats.victories_num == 0 && player_1_stats.victories_num == 1
         );   
-        assert_eq!(
-            player_1_stats.total_reward.clone(), Vec::from([
-                (
-                    "near".parse().unwrap(), 
-                    (2 * ONE_NEAR - ((2 * ONE_NEAR / BASIS_P as u128 )* MIN_FEES as u128))
-                )
-            ])
-        );
-        assert!(player_2_stats.total_reward.is_empty());
+        assert_eq!(player_1_stats.total_reward, (2 * ONE_NEAR - ((2 * ONE_NEAR / BASIS_P as u128 )* MIN_FEES as u128)));
+        assert_eq!(player_2_stats.total_reward, 0);
         // cheddar game
 
         testing_env!(ctx
@@ -933,9 +925,8 @@ mod tests {
             player_1_stats.victories_num == 0 && player_2_stats.victories_num == 1
         );
         assert_eq!(
-            player_2_stats.total_reward, Vec::from([(acc_cheddar(), (2 * ONE_CHEDDAR - ((2 * ONE_CHEDDAR / BASIS_P as u128) * MIN_FEES as u128)))]) 
-        );
-        assert!(player_1_stats.total_reward.is_empty());
+            player_2_stats.total_reward, (2 * ONE_CHEDDAR - ((2 * ONE_CHEDDAR / BASIS_P as u128) * MIN_FEES as u128) ));
+        assert_eq!(player_1_stats.total_reward, 0);
     }
     #[test]
     fn test_game_basics() {
@@ -997,12 +988,8 @@ mod tests {
         assert!(
             player_2_stats.victories_num == 0 && player_1_stats.victories_num == 1
         );   
-        assert_eq!(
-            player_1_stats.total_reward.clone(), Vec::from([
-                (acc_cheddar(), (2 * ONE_CHEDDAR - ((2 * ONE_CHEDDAR / BASIS_P as u128 )* MIN_FEES as u128)))
-            ])
-        );
-        assert!(player_2_stats.total_reward.is_empty());
+        assert_eq!(player_1_stats.total_reward,(2 * ONE_CHEDDAR - ((2 * ONE_CHEDDAR / BASIS_P as u128 )* MIN_FEES as u128)));
+        assert_eq!(player_2_stats.total_reward, 0);
     }
 
     #[test]
@@ -1511,15 +1498,7 @@ mod tests {
         ctr.claim_timeout_win(&game_id);
         assert!(ctr.get_stats(&player_1).victories_num == 1);
         assert!(ctr.get_stats(&player_2).victories_num == 0);
-        assert_eq!(
-            ctr.get_stats(&player_1).total_reward,
-            Vec::from([
-                (
-                    acc_cheddar(),
-                    (2 * ONE_CHEDDAR - (2 * ONE_CHEDDAR / BASIS_P as u128 * MIN_FEES as u128)) 
-                )
-            ])
-        )
+        assert_eq!(ctr.get_stats(&player_1).total_reward, (2 * ONE_CHEDDAR - (2 * ONE_CHEDDAR / BASIS_P as u128 * MIN_FEES as u128)));
     }
     #[test]
     fn test_claim_timeout_win_when_no_timeout() {

--- a/contracts/cheddar_3x3_tic_tac_toe/src/stats.rs
+++ b/contracts/cheddar_3x3_tic_tac_toe/src/stats.rs
@@ -18,8 +18,8 @@ pub struct Stats {
     pub games_num: u64,
     pub victories_num: u64,
     pub penalties_num: u64,
-    pub total_reward: UnorderedMap<TokenContractId, Balance>,
-    pub total_affiliate_reward: UnorderedMap<TokenContractId, Balance>,
+    pub total_reward: Balance,
+    pub total_affiliate_reward: Balance,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -37,8 +37,8 @@ pub struct StatsView {
     pub games_played: u64,
     pub victories_num: u64,
     pub penalties_num: u64,
-    pub total_reward: Vec<(TokenContractId, Balance)>,
-    pub total_affiliate_reward: Vec<(AffiliateId, Balance)>,
+    pub total_reward: Balance,
+    pub total_affiliate_reward: Balance,
 }
 #[near_bindgen]
 impl Contract {
@@ -49,8 +49,8 @@ impl Contract {
             games_played: stats.games_num, 
             victories_num: stats.victories_num, 
             penalties_num: stats.penalties_num, 
-            total_reward: stats.total_reward.to_vec(), 
-            total_affiliate_reward: stats.total_affiliate_reward.to_vec() 
+            total_reward: stats.total_reward, 
+            total_affiliate_reward: stats.total_affiliate_reward 
         }
     }
     pub fn get_user_penalties(&self, account_id: &AccountId) -> UserPenalties {
@@ -76,8 +76,8 @@ impl Stats {
             games_num: 0,
             victories_num: 0,
             penalties_num: 0,
-            total_reward: UnorderedMap::new(StorageKey::TotalRewards { account_id: account_id.clone() }),
-            total_affiliate_reward: UnorderedMap::new(StorageKey::TotalAffiliateRewards { account_id: account_id.clone() }),
+            total_reward: 0,
+            total_affiliate_reward: 0,
         }
     }
 }
@@ -91,7 +91,6 @@ impl Contract {
         }
     }
     pub(crate) fn internal_update_stats(&mut self,
-        token_id: Option<&AccountId>,
         account_id: &AccountId,
         action: UpdateStatsAction,
         additional_account_id: Option<AccountId>,
@@ -114,23 +113,13 @@ impl Contract {
                     stats.victories_num += 1;
                 },
                 UpdateStatsAction::AddTotalReward => {
-                    let token_id = match token_id {
-                        Some(id) => id,
-                        None => panic!("TokenId for update stats isn't set"),
-                    };
                     if let Some(added_balance) = balance {
-                        let cur_balance = stats.total_reward.get(token_id).unwrap_or(0);
-                        stats.total_reward.insert(token_id, &(cur_balance + added_balance));
+                        stats.total_reward += added_balance;
                     }
                 },
                 UpdateStatsAction::AddAffiliateReward => {
-                    let token_id = match token_id {
-                        Some(id) => id,
-                        None => panic!("TokenId for update stats isn't set"),
-                    };
                     if let Some(added_balance) = balance {
-                        let cur_balance = stats.total_affiliate_reward.get(token_id).unwrap_or(0);
-                        stats.total_affiliate_reward.insert(token_id, &(cur_balance + added_balance));
+                        stats.total_affiliate_reward += added_balance;
                     }
                 },
                 UpdateStatsAction::AddPenaltyGame => {

--- a/contracts/cheddar_5x5_tic_tac_toe/Makefile
+++ b/contracts/cheddar_5x5_tic_tac_toe/Makefile
@@ -25,10 +25,11 @@ deploy-testnet:
 	  "new" '{"cheddar": "'${CHEDDAR}'"}'
 
 deploy-dev:
-#rm neardev/tic_tac_toe/*
+# rm -r neardev/tic_tac_toe
 	@near dev-deploy --wasmFile ../../res/cheddar_big_tic_tac_toe.wasm  \
+	 			--initFunction "new" \
                 --projectKeyDirectory ./neardev/ \
-                'new' '{"cheddar": "'${CHEDDAR}'", "min_deposit": ${MIN_DEPOSIT}}'
+                --initArgs '{"cheddar": "'${CHEDDAR}'", "min_deposit": ${MIN_DEPOSIT}}'
 
 show-dev-account:
 	cat neardev/tic_tac_toe/dev-account

--- a/contracts/cheddar_5x5_tic_tac_toe/Makefile
+++ b/contracts/cheddar_5x5_tic_tac_toe/Makefile
@@ -19,15 +19,17 @@ test-unit:
 
 CTR_T=tic-tac-toe-5-v1.cheddar.testnet
 CHEDDAR=token-v3.cheddar.testnet
+MIN_DEPOSIT=20
 deploy-testnet:
 	@NEAR_ENV=testnet near deploy ${CTR_T} ../../res/cheddar_big_tic_tac_toe.wasm \
 	  "new" '{"cheddar": "'${CHEDDAR}'"}'
 
 deploy-dev:
 #rm neardev/tic_tac_toe/*
-	@near dev-deploy ../../cheddar_big_tic_tac_toe.wasm \
-		--projectKeyDirectory ./neardev/tic_tac_toe/ \
-		"new" '{"cheddar": "'${CHEDDAR}'"}'
+	@near dev-deploy --wasmFile ../../res/cheddar_big_tic_tac_toe.wasm  \
+                --initFunction "new" \
+                --projectKeyDirectory ./neardev/ \
+                --initArgs '{"cheddar": "'${CHEDDAR}'", "min_deposit": ${MIN_DEPOSIT}}'
 
 show-dev-account:
 	cat neardev/tic_tac_toe/dev-account

--- a/contracts/cheddar_5x5_tic_tac_toe/Makefile
+++ b/contracts/cheddar_5x5_tic_tac_toe/Makefile
@@ -27,9 +27,8 @@ deploy-testnet:
 deploy-dev:
 #rm neardev/tic_tac_toe/*
 	@near dev-deploy --wasmFile ../../res/cheddar_big_tic_tac_toe.wasm  \
-                --initFunction "new" \
                 --projectKeyDirectory ./neardev/ \
-                --initArgs '{"cheddar": "'${CHEDDAR}'", "min_deposit": ${MIN_DEPOSIT}}'
+                'new' '{"cheddar": "'${CHEDDAR}'", "min_deposit": ${MIN_DEPOSIT}}'
 
 show-dev-account:
 	cat neardev/tic_tac_toe/dev-account

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -75,9 +75,8 @@ impl Board {
         }
         Ok(())
     }
-    pub fn check_winner(&mut self, position: &Coords) -> bool {
+    pub fn check_winner(&self, position: &Coords) -> bool {
         let expected = Some(self.current_piece.other());
-        self.current_piece = self.current_piece.other();
         let mut c = position.clone();
         let mut counter = 1;
         // 1. check rows
@@ -594,7 +593,6 @@ mod test {
         let game_id: u64 = 1;
         // initialize the board
         let mut board = Board::new(game_id);
-        assert_eq!(board.current_piece, Piece::O);
 
         // prepare the board
         board.tiles.insert(&Coords { x: 24, y: 0}, &piece_2);
@@ -602,7 +600,6 @@ mod test {
         board.tiles.insert(&Coords { x: 24, y: 2}, &piece_2);
         board.tiles.insert(&Coords { x: 24, y: 3}, &piece_2);
         let result = board.check_winner(&Coords{ x: 24, y: 4 });
-        assert_eq!(board.current_piece, Piece::X);
         assert_eq!(result, true); 
     }
     #[test]

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -93,7 +93,7 @@ impl Board {
             return true;
         }
         c = position.clone();
-        for _ in 1..=max(4, BOARD_SIZE - 1 - position.x as usize) {
+        for _ in 1..=max(4, BOARD_SIZE - 1 - position.x) {
             c.x = c.x + 1;
             if self.tiles.get(&c) == expected {
                 counter += 1;
@@ -119,7 +119,7 @@ impl Board {
             return true;
         }
         c = position.clone();
-        for _ in 1..=max(4, BOARD_SIZE - 1 - position.y as usize) {
+        for _ in 1..=max(4, BOARD_SIZE - 1 - position.y) {
             c.y = c.y + 1;
             if self.tiles.get(&c) == expected {
                 counter += 1;
@@ -152,7 +152,7 @@ impl Board {
             return true;
         }
         c = position.clone();
-        for _ in 1..=max(4, BOARD_SIZE - 1 - max(position.x, position.y) as usize) {
+        for _ in 1..=max(4, BOARD_SIZE - 1 - max(position.x, position.y)) {
             c.x = c.x + 1;
             c.y = c.y + 1;
             if self.tiles.get(&c) == expected {
@@ -227,7 +227,7 @@ impl Board {
         return Tiles { o_coords, x_coords };
     }
     pub fn get_last_move(&self) -> Coords {
-        return self.last_move.unwrap().clone();
+        return self.last_move.clone().unwrap();
     }
     pub fn get_last_move_piece(&self) -> Piece {
         if self.current_piece == Piece::O {

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -227,7 +227,7 @@ impl Board {
         return Tiles { o_coords, x_coords };
     }
     pub fn get_last_move(&self) -> Coords {
-        return self.last_move.clone().unwrap();
+        return self.last_move.unwrap().clone();
     }
     pub fn get_last_move_piece(&self) -> Piece {
         if self.current_piece == Piece::O {

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -35,9 +35,9 @@ pub struct Coords {
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
-// #[serde(crate = "near_sdk::serde")]
 pub struct Board {
     pub tiles: UnorderedMap<Coords, Piece>,
+    pub last_move: Option<Coords>,
     /// X or O: who is currently playing
     pub current_piece: Piece,
     pub winner: Option<Winner>,
@@ -52,6 +52,7 @@ impl Board {
             tiles: UnorderedMap::new(StorageKey::GameBoard { game_id }),
             current_piece: Piece::O,
             winner: None,
+            last_move: None,
         }
     }
     pub fn check_move(&self, coords: &Coords) -> Result<(), MoveError> {
@@ -224,6 +225,17 @@ impl Board {
             }
         }
         return Tiles { o_coords, x_coords };
+    }
+    pub fn get_last_move(&self) -> Coords {
+        return self.last_move.clone().unwrap();
+    }
+    pub fn get_last_move_piece(&self) -> Piece {
+        if self.current_piece == Piece::O {
+            return Piece::X;
+        } else {
+            return Piece::O;
+        }
+
     }
 }
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -59,7 +59,7 @@ impl Board {
         if self.winner.is_some() {
             return Err(MoveError::GameOver);
         }
-        if coords.y >= BOARD_SIZE as u8 || coords.x >= BOARD_SIZE as u8 {
+        if coords.y >= BOARD_SIZE || coords.x >= BOARD_SIZE {
             return Err(MoveError::InvalidPosition {
                 row: coords.y,
                 col: coords.x,
@@ -205,10 +205,10 @@ impl Board {
             return;
         }
         if self.check_winner(coords) {
-            if self.current_piece == Piece::X {
+            if self.current_piece.other() == Piece::X {
                 self.winner = Some(Winner::X);
                 print!("X is the winner");
-            } else if self.current_piece == Piece::O {
+            } else if self.current_piece.other() == Piece::O {
                 self.winner = Some(Winner::O);
                 print!("O is the winner");
             }
@@ -226,8 +226,8 @@ impl Board {
         }
         return Tiles { o_coords, x_coords };
     }
-    pub fn get_last_move(&self) -> Coords {
-        return self.last_move.clone().unwrap();
+    pub fn get_last_move(&self) -> Option<Coords> {
+        return self.last_move.clone();
     }
     pub fn get_last_move_piece(&self) -> Piece {
         if self.current_piece == Piece::O {
@@ -261,14 +261,14 @@ mod test {
 
         // make move
         let result = board.check_move(&Coords {
-            x: BOARD_SIZE as u8,
-            y: BOARD_SIZE as u8,
+            x: BOARD_SIZE,
+            y: BOARD_SIZE,
         });
         assert_eq!(
             result,
             Err(MoveError::InvalidPosition {
-                row: BOARD_SIZE as u8,
-                col: BOARD_SIZE as u8
+                row: BOARD_SIZE,
+                col: BOARD_SIZE
             })
         );
     }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/board.rs
@@ -75,8 +75,9 @@ impl Board {
         }
         Ok(())
     }
-    pub fn check_winner(&self, position: &Coords) -> bool {
+    pub fn check_winner(&mut self, position: &Coords) -> bool {
         let expected = Some(self.current_piece.other());
+        self.current_piece = self.current_piece.other();
         let mut c = position.clone();
         let mut counter = 1;
         // 1. check rows
@@ -593,6 +594,7 @@ mod test {
         let game_id: u64 = 1;
         // initialize the board
         let mut board = Board::new(game_id);
+        assert_eq!(board.current_piece, Piece::O);
 
         // prepare the board
         board.tiles.insert(&Coords { x: 24, y: 0}, &piece_2);
@@ -600,6 +602,7 @@ mod test {
         board.tiles.insert(&Coords { x: 24, y: 2}, &piece_2);
         board.tiles.insert(&Coords { x: 24, y: 3}, &piece_2);
         let result = board.check_winner(&Coords{ x: 24, y: 4 });
+        assert_eq!(board.current_piece, Piece::X);
         assert_eq!(result, true); 
     }
     #[test]

--- a/contracts/cheddar_5x5_tic_tac_toe/src/callbacks.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/callbacks.rs
@@ -14,4 +14,23 @@ impl Contract {
             self.available_players.insert(&user, config);
         }
     }
+    #[private]
+    pub fn transfer_callback(&mut self, user: AccountId, stats: &StatsView) {
+        if promise_result_as_failed() {
+            log!(
+                "Transfer failed. Recovering state for {} account",
+                user.clone(),
+            );
+            let stats = Stats  {
+                    referrer_id: stats.referrer_id.clone(),
+                    affiliates: UnorderedSet::new(b"s"), //TODO: not sure why we store it as unordered set
+                    games_num: stats.games_played,
+                    victories_num: stats.victories_num,
+                    penalties_num: stats.penalties_num,
+                    total_reward: stats.total_reward,
+                    total_affiliate_reward: stats.total_affiliate_reward,
+            };
+            self.stats.insert(&user.clone(), &stats);
+        }
+    }
 }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/game.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/game.rs
@@ -1,3 +1,5 @@
+use core::panic;
+
 use crate::*;
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Clone, Debug)]

--- a/contracts/cheddar_5x5_tic_tac_toe/src/internal.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/internal.rs
@@ -109,7 +109,7 @@ impl Contract {
             .unwrap_or(0)
             .checked_mul(self.service_fee as u128)
             .unwrap_or(0);
-        assert!(fees_amount > 0, "Incorrect fees computing");
+        // assert!(fees_amount > 0, "Incorrect fees computing"); //TODO: i think we do not need this assertion since we allow zero fees
 
         let winner_reward: Balance = players_deposit.0 - fees_amount;
 
@@ -139,8 +139,10 @@ impl Contract {
                 Some(amount) => amount,
                 None => panic!("Failed divide deposit to refund GameDeposit (GameResult::Tie)"),
             };
+            print!("refund ammount {}", refund_amount);
+            print!("reward.balance.0 {}", reward.balance.0);
             assert!(
-                refund_amount.checked_mul(PLAYERS_NUM as u128) < Some(reward.balance.0),
+                refund_amount.checked_mul(PLAYERS_NUM as u128) <= Some(reward.balance.0), //TODO: I think it must be smaller or equal since we allow zero fees
                 "Incorrect Tie refund amount calculation"
             );
             log!("Tie. Refund: {}", refund_amount);

--- a/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
@@ -743,10 +743,10 @@ mod tests {
         make_move(&mut ctx, &mut ctr, &player_1_n, &game_id_near, 0, 1);
         make_move(&mut ctx, &mut ctr, &player_2_n, &game_id_near, 0, 0);
         make_move(&mut ctx, &mut ctr, &player_1_n, &game_id_near, 1, 1);
-       make_move(&mut ctx, &mut ctr, &player_2_n, &game_id_near, 2, 2);
-       make_move(&mut ctx, &mut ctr, &player_1_n, &game_id_near, 0, 2);
-     make_move(&mut ctx, &mut ctr, &player_2_n, &game_id_near, 2, 0);
-     make_move(&mut ctx, &mut ctr, &player_1_n, &game_id_near, 2, 1);
+        make_move(&mut ctx, &mut ctr, &player_2_n, &game_id_near, 2, 2);
+        make_move(&mut ctx, &mut ctr, &player_1_n, &game_id_near, 0, 2);
+        make_move(&mut ctx, &mut ctr, &player_2_n, &game_id_near, 2, 0);
+        make_move(&mut ctx, &mut ctr, &player_1_n, &game_id_near, 2, 1);
 
 
         let player_1_stats = ctr.get_stats(&opponent2);
@@ -1278,6 +1278,11 @@ mod tests {
     #[test]
     fn test_new_views() -> Result<(), std::io::Error>{
         let (mut ctx, mut ctr) = game_basics()?;
+        assert_eq!(
+            ctr.get_active_games().len(), 1, 
+            "first and second games need to be removed (expired) after max_game_duration passed for this"
+        );
+
 
         println!("ContractParams: {:#?}", ctr.get_contract_params());
         println!("TotalStatsNum: {:#?}", ctr.get_total_stats_num());

--- a/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
@@ -235,7 +235,7 @@ impl Contract {
 
     pub fn get_last_move(&self, game_id: &GameId) -> (Coords, Piece){
         let game = self.internal_get_game(game_id);
-        return (game.board.get_last_move(), game.board.get_last_move_piece());
+        return (game.board.get_last_move(), game.current_piece.other());
     }
     
 
@@ -1511,17 +1511,16 @@ mod tests {
         assert_eq!(game.board.current_piece, Piece::O);
 
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
-
         make_move(&mut ctx, &mut ctr, &player_1, &game_id, 0, 0);
-        let (last_move, piece) = get_last_move(&mut ctx, &mut ctr, &player_1, &game_id);
+        let (last_move, last_piece) = get_last_move(&mut ctx, &mut ctr, &player_1, &game_id);
         assert_eq!(last_move.x, 0);
         assert_eq!(last_move.y, 0);
-        assert_eq!(piece, Piece::O);
+        assert_eq!(last_piece, Piece::O);
         make_move(&mut ctx, &mut ctr, &player_2, &game_id, 0, 1);
-        let (last_move, piece) = get_last_move(&mut ctx, &mut ctr, &player_2, &game_id);
+        let (last_move, last_piece) = get_last_move(&mut ctx, &mut ctr, &player_2, &game_id);
         assert_eq!(last_move.x, 1);
         assert_eq!(last_move.y, 0);
-        assert_eq!(piece, Piece::X);
+        assert_eq!(last_piece, Piece::X);
         
     }
 }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
@@ -1513,13 +1513,15 @@ mod tests {
         assert!(ctr.get_active_games().contains(&(game_id, GameView::from(&game))));
 
         make_move(&mut ctx, &mut ctr, &player_1, &game_id, 0, 0);
-        let (last_move, _) = get_last_move(&mut ctx, &mut ctr, &player_1, &game_id);
+        let (last_move, piece) = get_last_move(&mut ctx, &mut ctr, &player_1, &game_id);
         assert_eq!(last_move.x, 0);
         assert_eq!(last_move.y, 0);
+        assert_eq!(piece, Piece::O);
         make_move(&mut ctx, &mut ctr, &player_2, &game_id, 0, 1);
-        let (last_move, _) = get_last_move(&mut ctx, &mut ctr, &player_2, &game_id);
+        let (last_move, piece) = get_last_move(&mut ctx, &mut ctr, &player_2, &game_id);
         assert_eq!(last_move.x, 1);
         assert_eq!(last_move.y, 0);
+        assert_eq!(piece, Piece::X);
         
     }
 }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/lib.rs
@@ -782,6 +782,14 @@ mod tests {
     }
 
     #[test]
+    fn test_near_deposit() {
+        let (mut ctx, mut ctr) = setup_contract(user(), Some(MIN_FEES), None,  Some(MIN_GAME_DURATION_SEC));
+        assert!(ctr.get_available_players().is_empty());
+        make_available_near(&mut ctx, &mut ctr, &user(), ONE_NEAR, None, Some(referrer()));
+        make_available_near(&mut ctx, &mut ctr, &opponent(), ONE_NEAR, Some(user()), None);
+    }
+
+    #[test]
     fn make_available_unavailable_near() {
         let (mut ctx, mut ctr) = setup_contract(user(), Some(MIN_FEES), None,  Some(MIN_GAME_DURATION_SEC));
         assert!(ctr.get_available_players().is_empty());
@@ -1278,11 +1286,6 @@ mod tests {
     #[test]
     fn test_new_views() -> Result<(), std::io::Error>{
         let (mut ctx, mut ctr) = game_basics()?;
-        assert_eq!(
-            ctr.get_active_games().len(), 1, 
-            "first and second games need to be removed (expired) after max_game_duration passed for this"
-        );
-
 
         println!("ContractParams: {:#?}", ctr.get_contract_params());
         println!("TotalStatsNum: {:#?}", ctr.get_total_stats_num());

--- a/contracts/cheddar_5x5_tic_tac_toe/src/player.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/player.rs
@@ -21,4 +21,10 @@ impl Piece {
             _ => Piece::O
         }
     }
+    pub fn to_string(self) -> String {
+        match self {
+            Piece::X => String::from("X"),
+            Piece::O => String::from("O"),
+        }
+    }
 }

--- a/contracts/cheddar_5x5_tic_tac_toe/src/stats.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/stats.rs
@@ -18,8 +18,8 @@ pub struct Stats {
     pub games_num: u64,
     pub victories_num: u64,
     pub penalties_num: u64,
-    pub total_reward: UnorderedMap<TokenContractId, Balance>,
-    pub total_affiliate_reward: UnorderedMap<TokenContractId, Balance>,
+    pub total_reward: Balance,
+    pub total_affiliate_reward: Balance,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -37,8 +37,8 @@ pub struct StatsView {
     pub games_played: u64,
     pub victories_num: u64,
     pub penalties_num: u64,
-    pub total_reward: Vec<(TokenContractId, Balance)>,
-    pub total_affiliate_reward: Vec<(AffiliateId, Balance)>,
+    pub total_reward: Balance,
+    pub total_affiliate_reward: Balance,
 }
 #[near_bindgen]
 impl Contract {
@@ -49,8 +49,8 @@ impl Contract {
             games_played: stats.games_num, 
             victories_num: stats.victories_num, 
             penalties_num: stats.penalties_num, 
-            total_reward: stats.total_reward.to_vec(), 
-            total_affiliate_reward: stats.total_affiliate_reward.to_vec() 
+            total_reward: stats.total_reward, 
+            total_affiliate_reward: stats.total_affiliate_reward 
         }
     }
     pub fn get_user_penalties(&self, account_id: &AccountId) -> UserPenalties {
@@ -76,8 +76,8 @@ impl Stats {
             games_num: 0,
             victories_num: 0,
             penalties_num: 0,
-            total_reward: UnorderedMap::new(StorageKey::TotalRewards { account_id: account_id.clone() }),
-            total_affiliate_reward: UnorderedMap::new(StorageKey::TotalAffiliateRewards { account_id: account_id.clone() }),
+            total_reward: 0,
+            total_affiliate_reward: 0,
         }
     }
 }
@@ -114,23 +114,13 @@ impl Contract {
                     stats.victories_num += 1;
                 },
                 UpdateStatsAction::AddTotalReward => {
-                    let token_id = match token_id {
-                        Some(id) => id,
-                        None => panic!("TokenId for update stats isn't set"),
-                    };
                     if let Some(added_balance) = balance {
-                        let cur_balance = stats.total_reward.get(token_id).unwrap_or(0);
-                        stats.total_reward.insert(token_id, &(cur_balance + added_balance));
+                        stats.total_reward += added_balance;
                     }
                 },
                 UpdateStatsAction::AddAffiliateReward => {
-                    let token_id = match token_id {
-                        Some(id) => id,
-                        None => panic!("TokenId for update stats isn't set"),
-                    };
                     if let Some(added_balance) = balance {
-                        let cur_balance = stats.total_affiliate_reward.get(token_id).unwrap_or(0);
-                        stats.total_affiliate_reward.insert(token_id, &(cur_balance + added_balance));
+                        stats.total_affiliate_reward += added_balance;
                     }
                 },
                 UpdateStatsAction::AddPenaltyGame => {

--- a/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
@@ -12,8 +12,6 @@ pub(crate) const GAS_FOR_FT_TRANSFER: Gas = Gas(Gas::ONE_TERA.0 * 10);
 pub(crate) const MAX_FEES: u16 = 1000; // 10%
 pub(crate) const BASIS_P: u16 = 10000; // 100%
 pub(crate) const TIMEOUT_WIN: u64 = 300000000000; // 5 minutes timeout
-
-pub(crate) const MIN_DEPOSIT_NEAR: Balance = ONE_NEAR; // 0.1 NEAR
 pub(crate) const MIN_DEPOSIT_CHEDDAR: Balance =  10; //TODO: how much the minimum deposit should be?
 
 pub(crate) type TokenContractId = AccountId;

--- a/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
@@ -23,7 +23,6 @@ pub(crate) type AffiliateId = AccountId;
 /// This constant can be used to set the board size
 pub(crate) const BOARD_SIZE: u8 = 5;
 pub(crate) const MAX_NUM_TURNS: u64 = (BOARD_SIZE as u64) * (BOARD_SIZE as u64);
-pub(crate) const PLAYERS_NUM: usize = 2;
 
 /// Returns true if the promise was failed. Otherwise returns false.
 /// Fails if called outside a callback that received 1 promise result.

--- a/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
@@ -19,8 +19,8 @@ pub(crate) type GameId = u64;
 pub(crate) type AffiliateId = AccountId;
 
 /// This constant can be used to set the board size
-pub(crate) const BOARD_SIZE: usize = 25;
-pub(crate) const MAX_NUM_TURNS: u64 = (BOARD_SIZE*BOARD_SIZE) as u64;
+pub(crate) const BOARD_SIZE: u8 = 25;
+pub(crate) const MAX_NUM_TURNS: u64 = BOARD_SIZE as u64 *BOARD_SIZE as u64;
 
 
 /// Returns true if the promise was failed. Otherwise returns false.

--- a/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/utils.rs
@@ -13,7 +13,8 @@ pub(crate) const MAX_FEES: u16 = 1000; // 10%
 pub(crate) const BASIS_P: u16 = 10000; // 100%
 pub(crate) const TIMEOUT_WIN: u64 = 300000000000; // 5 minutes timeout
 
-pub(crate) const MIN_DEPOSIT_NEAR: Balance = ONE_NEAR / 10; // 0.1 NEAR
+pub(crate) const MIN_DEPOSIT_NEAR: Balance = ONE_NEAR; // 0.1 NEAR
+pub(crate) const MIN_DEPOSIT_CHEDDAR: Balance =  10; //TODO: how much the minimum deposit should be?
 
 pub(crate) type TokenContractId = AccountId;
 pub(crate) type GameId = u64;

--- a/contracts/cheddar_5x5_tic_tac_toe/src/views.rs
+++ b/contracts/cheddar_5x5_tic_tac_toe/src/views.rs
@@ -178,4 +178,7 @@ impl Contract {
 
         result
     }
+    pub fn get_max_game_duration(&self) -> u64 {
+        return self.max_game_duration;
+    }
 }

--- a/contracts/cheddar_5x5_tic_tac_toe/testnet.sh
+++ b/contracts/cheddar_5x5_tic_tac_toe/testnet.sh
@@ -31,6 +31,19 @@ near dev-deploy --wasmFile ./res/cheddar_big_tic_tac_toe.wasm  \
             }
 		}'
 
+
+
+near dev-deploy --wasmFile ./res/cheddar_big_tic_tac_toe.wasm  \
+		--initFunction "new" \
+		--projectKeyDirectory ./neardev/ \
+		--initArgs '{"cheddar": token-v3.cheddar.testnet, "min_deposit": 20, "config": {
+                "fee": 200,
+                "referrer_fee_share": 5000,
+                "max_game_duration_sec": 3600,
+                "max_stored_games": 50
+            }
+		}'
+
 TICTACTOE=$(cat neardev/tic_tac_toe/dev-account)
 
 echo set_max_duration

--- a/contracts/cheddar_5x5_tic_tac_toe/testnet.sh
+++ b/contracts/cheddar_5x5_tic_tac_toe/testnet.sh
@@ -31,19 +31,6 @@ near dev-deploy --wasmFile ./res/cheddar_big_tic_tac_toe.wasm  \
             }
 		}'
 
-
-
-near dev-deploy --wasmFile ./res/cheddar_big_tic_tac_toe.wasm  \
-		--initFunction "new" \
-		--projectKeyDirectory ./neardev/ \
-		--initArgs '{"cheddar": token-v3.cheddar.testnet, "min_deposit": 20, "config": {
-                "fee": 200,
-                "referrer_fee_share": 5000,
-                "max_game_duration_sec": 3600,
-                "max_stored_games": 50
-            }
-		}'
-
 TICTACTOE=$(cat neardev/tic_tac_toe/dev-account)
 
 echo set_max_duration


### PR DESCRIPTION
Remove support for other tokens. Accept only cheddar. 
- changed the logic so only cheddar is supported
- updated the tests 
- modify the `Stats` and `StatsView` structs
- add callback for reward distribution 
- add `get_last_move` method and test for it
- fix the `deploy-dev` script in `Makefile`